### PR TITLE
Add 'Direction::turn' method and fix damage methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+tag:
+	@README_TAG=$$( grep GIT_TAG README.md | sed -e "s/.* //" ); \
+	if git tag | grep -q $$README_TAG; then \
+	  echo "Tag already exists"; \
+	else \
+	  git tag $$README_TAG; \
+	  git push --tags; \
+	fi
+
+format:
+	find . -name "*.cpp" -o -name "*.h" -o -name "*.tpp" | xargs clang-format -i

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ include(FetchContent) # once in the project to include the module
 
 FetchContent_Declare(librobots
         GIT_REPOSITORY https://github.com/HEIGVD-PRG1-F-2022/librobots.git
-        GIT_TAG v0.2.2
+        GIT_TAG v0.2.3
         )
 FetchContent_MakeAvailable(librobots)
 

--- a/include/librobots/Direction.h
+++ b/include/librobots/Direction.h
@@ -67,6 +67,10 @@ public:
     /// The magnitude of the direction.
     [[nodiscard]] double mag() const;
 
+    /// Change the direction of the vector counterclockwise.
+    /// The angle is given in radians.
+    Direction &rotate(double angle);
+
     /// Negate the direction
     [[nodiscard]] Direction &neg();
 

--- a/src/Direction.cpp
+++ b/src/Direction.cpp
@@ -67,6 +67,14 @@ Direction &Direction::neg() {
     return *this;
 }
 
+Direction &Direction::rotate(double angle) {
+    double newX = dx * cos(angle) - dy * sin(angle);
+    double newY = dx * sin(angle) + dy * cos(angle);
+    dx = int(newX);
+    dy = int(newY);
+    return *this;
+}
+
 Direction operator+(Direction dir, const Direction &other) {
     return dir += other;
 }

--- a/src/RobotState.cpp
+++ b/src/RobotState.cpp
@@ -66,15 +66,18 @@ void RobotState::actionPower(unsigned bonusPower) {
 
 void RobotState::checkCollision(RobotState &other) {
     if (pos == other.pos) {
-        if (energy <= other.energy) {
-            other.energy -= energy;
+        auto damage = min(energy, other.energy);
+        energy -= damage;
+        other.energy -= damage;
+        if (energy == 0) {
             deathCause = "Collision with " + other.getName();
-            energy = 0;
         } else {
-            energy -= other.energy;
-            updates_cache.push_back(Message::updateDamage(Direction(), other.energy));
-            other.energy = 0;
+            other.updates_cache.push_back(Message::updateDamage(Direction(), damage));
+        }
+        if (other.energy == 0) {
             other.deathCause = "Collision with " + getName();
+        } else {
+            updates_cache.push_back(Message::updateDamage(Direction(), damage));
         }
     }
 }


### PR DESCRIPTION
This PR adds a new method 'Direction::turn', which allows to turn a direction by a given angle. This is useful when calculating in which direction the robot should move.

It also has a fix for RobotState::checkCollision which didn't update the damage calculation in case of a colision.